### PR TITLE
Compatibility with Scala 2.10 - 2.12 by using macro-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ a given JavaBean to the Scala object to which it is applied.
 
 ## Installation
 
-The scala-binutils package is published to [Bintray](https://bintray.com/yetu/maven/scala-beanutils). To be able to use
+The scala-beanutils package is published to [Bintray](https://bintray.com/yetu/maven/scala-beanutils). To be able to use
 it, you need to add the repository to your build:
 
 ```scala
@@ -24,8 +24,7 @@ libraryDependencies += "com.yetu" %% "scala-beanutils" % "0.1.4"
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 ```
 
-Note that, currently, we only have published artifacts for Scala 2.10. This is due to the fact that we are still using
-2.10 and that there are differences between how Macro Paradise works in 2.10 and 2.11.
+scala-beanutils package is cross-built against Scala 2.10, 2.11 and 2.12.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The scala-binutils package is published to [Bintray](https://bintray.com/yetu/ma
 it, you need to add the repository to your build:
 
 ```scala
-resolvers += Resolver.url("yetu-bintray-repo", "https://bintray.com/yetu/maven")
+resolvers += Resolver.url("yetu-bintray-repo", url("https://dl.bintray.com/yetu/maven"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.sonatypeRepo("releases")
 ```
 
 After that, add the following dependency, as well as the
@@ -20,7 +21,7 @@ macro annotations):
 
 ```scala
 libraryDependencies += "com.yetu" %% "scala-beanutils" % "0.1.4"
-libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 ```
 
 Note that, currently, we only have published artifacts for Scala 2.10. This is due to the fact that we are still using

--- a/macros/src/main/scala/com/yetu/beanutils/beanCompanion.scala
+++ b/macros/src/main/scala/com/yetu/beanutils/beanCompanion.scala
@@ -3,11 +3,14 @@ package com.yetu.beanutils
 import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros._
+import scala.reflect.macros.whitebox
+import macrocompat.bundle
 
-object beanCompanionMacro {
+@bundle
+class beanCompanionMacro(val c: whitebox.Context) {
   val accessorRegex = "^((get)|(is)|(has))[A-Z]".r
 
-  def impl(c: Context)(annottees: c.Expr[ Any ]*): c.Expr[ Any ] = {
+  def impl(annottees: c.Expr[ Any ]*): c.Expr[ Any ] = {
     import c.universe._
 
       /**

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,11 +4,12 @@ import sbt.Keys._
 import sbt._
 
 object BuildSettings {
+  val scalaVersions = Seq("2.11.8", "2.10.6", "2.12.1")
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := "com.yetu",
     version := "0.1.5-SNAPSHOT",
-    scalaVersion := "2.10.5",
-    crossScalaVersions := Seq("2.10.5", "2.11.6"),
+    scalaVersion := scalaVersions.head,
+    crossScalaVersions := scalaVersions,
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-J-DbeanCompanion.debug=true"),
     licenses := ("Apache-2.0", new java.net.URL("http://www.apache.org/licenses/LICENSE-2.0.txt")) :: Nil,
     publishArtifact := false
@@ -18,7 +19,7 @@ object BuildSettings {
 object ScalaBeanUtilsBuild extends Build {
   import BuildSettings._
 
-  val macroParadise = compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" % "compile" cross CrossVersion.full)
+  val macroParadise = compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "compile" cross CrossVersion.full)
 
   lazy val root: Project = Project(
     "root",
@@ -33,12 +34,14 @@ object ScalaBeanUtilsBuild extends Build {
       libraryDependencies := (
         // quasiquotes are alredy added to scala-reflect starting in 2.11, but they have to be explicitly brought in for 2.10
         CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((2, 10)) ⇒ libraryDependencies.value :+ "org.scalamacros" %% "quasiquotes" % "2.1.0-M5"
+          case Some((2, 10)) ⇒ libraryDependencies.value :+ "org.scalamacros" %% "quasiquotes" % "2.1.0"
           case _             ⇒ libraryDependencies.value
         }
       ),
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        "org.typelevel" %% "macro-compat" % "1.1.1",
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
         macroParadise
       ),
       resolvers += Resolver.sonatypeRepo("releases"),
@@ -60,7 +63,7 @@ object ScalaBeanUtilsBuild extends Build {
     settings = buildSettings ++ Seq(
       libraryDependencies ++= Seq(
         macroParadise,
-        "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+        "org.scalatest" %% "scalatest" % "3.0.1" % "test"
       ),
       publishArtifact := false
     )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13


### PR DESCRIPTION
Hi @mcamou,

here comes the [PR originally issued against the yetu repo](https://github.com/yetu/scala-beanutils/pull/2):

I've used Miles Sabin's [macro-compat](https://github.com/milessabin/macro-compat) library to make scala-beanutils compatible with all major Scala versions.
Tests are green for all versions, so it would be nice if you could cross-publish this :+1: 

Best
  Martin